### PR TITLE
Updated version number after token validity check

### DIFF
--- a/check_nls_commands.php
+++ b/check_nls_commands.php
@@ -6,7 +6,7 @@
 //  
 // $Id: $mcapra@nagios.com
 define("PROGRAM", 'check_nls_commands.php');
-define("VERSION", '1.0.0');
+define("VERSION", '1.0.1');
 define("STATUS_OK", 0);
 define("STATUS_WARNING", 1);
 define("STATUS_CRITICAL", 2);


### PR DESCRIPTION
The validity of the API token for Nagios Log Server access is now checked. Should the token be incorrect NLS returns "UNKNOWN - Could not authenticate. Invalid token given".